### PR TITLE
refactor(cargo): specify the matching tag for dependencies against the specific sgx sdk

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,21 +106,21 @@ pattern = []
 
 # For very fast prefix literal matching.
 [dependencies.aho-corasick]
-#version = "0.7.6"
 optional = true
 git = "https://github.com/mesalock-linux/aho-corasick-sgx"
+tag = "sgx_1.1.0"
 
 # For skipping along search text quickly when a leading byte is known.
 [dependencies.memchr]
-#version = "2.2.1"
 optional = true
 git = "https://github.com/mesalock-linux/rust-memchr-sgx"
+tag = "sgx_1.1.0"
 
 # For managing regex caches quickly across multiple threads.
 [dependencies.thread_local]
-#version = "0.3.6"
 optional = true
 git = "https://github.com/mesalock-linux/thread_local-rs-sgx"
+tag = "sgx_1.1.0"
 
 # For parsing regular expressions.
 [dependencies.regex-syntax]


### PR DESCRIPTION
It's to avoid the breaking due to the future upgrading of teaclave-sgx-sdk, which triggered a horrible collapse of SGX-based crates during upgrading teaclave-sgx-sdk from v1.0.9 to v1.1.0 before